### PR TITLE
Исправление включения Utils.h в Quaternion.h

### DIFF
--- a/src/Quaternion/Quaternion.h
+++ b/src/Quaternion/Quaternion.h
@@ -10,7 +10,7 @@
 #include <iterator>
 #include <assert.h>
 
-#include <Quaternion/Utils.h>
+#include "Utils.h"
 
 namespace IntroSatLib {
 


### PR DESCRIPTION
Изменил форму include с треугольными скобками на форму с кавычками, чтобы исправить ошибку, которая возникает, когда директория src не добавлена в Include Paths в STM32CubeIde.